### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ A simple python lib to print data as ascii histograms
     :target: http://py-ascii-graph.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. .. image:: https://pypip.in/py_versions/ascii_graph/badge.svg
+.. .. image:: https://img.shields.io/pypi/pyversions/ascii_graph.svg
 ..    :target: https://pypi.python.org/pypi/ascii_graph
 ..    :alt: Supported Python Versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ascii-graph))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ascii-graph`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.